### PR TITLE
Correction de typos

### DIFF
--- a/Genma_SMS_Chiffres_Silence_Signal.tex
+++ b/Genma_SMS_Chiffres_Silence_Signal.tex
@@ -134,7 +134,7 @@ Google fournit la fonctionnalité qui permet en quelque sorte de réveiller votr
 \frametitle{Signal et les SMS 1/2}
 
 \justifying{
-Signal, par sécurité, utilise une base de données de messages séparée de celle du système (ce qui empêche les autres applications de fourrer leur nez dans vos SMS et permet optionn	ellement de protéger l'application par mot de passe).}
+Signal, par sécurité, utilise une base de données de messages séparée de celle du système (ce qui empêche les autres applications de fourrer leur nez dans vos SMS et permet optionnellement de protéger l'application par mot de passe).}
 \\~\\
 \justifying{
 Si vous dé-installez Signal, vous perdez les messages reçu sur Signal depuis son installation.
@@ -143,7 +143,7 @@ Avant de dé-installer Signal, pensez à exporter vos messages.
 \end{frame}
 
 \begin{frame}
-\frametitle{Signal et les SMS 1/2}
+\frametitle{Signal et les SMS 2/2}
 
 \justifying{
 Corollaire: Après:


### PR DESCRIPTION
- Grand espace chelou à la ligne 137 sur optionnellement
- Titre de la slide suivante (ligne 146) devient 2/2